### PR TITLE
Première version d'héritage d'entités

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 ###> symfony/web-server-bundle ###
 /.web-server-pid
 ###< symfony/web-server-bundle ###
+
+/.vscode/

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -2,16 +2,65 @@
 
 namespace App\DataFixtures;
 
+use App\Entity\Author;
+use App\Entity\Framework;
+use App\Entity\Level;
+use App\Entity\Program;
+use App\Entity\Ressource;
+use App\Entity\TopicFramework;
+use App\Entity\TopicProgrammingLanguage;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 
 class AppFixtures extends Fixture
 {
-    public function load(ObjectManager $manager)
-    {
-        // $product = new Product();
-        // $manager->persist($product);
+  public function load(ObjectManager $manager)
+  {
+    $fabPot = new Author();
+    $fabPot->setName('Fabien Potencier')
+      ->setWebsite('https://symfony.com/');
+    $manager->persist($fabPot);
 
-        $manager->flush();
-    }
+    $intermediate = new Level();
+    $intermediate->setName('intermédiaire');
+    $manager->persist($intermediate);
+
+    $php = new Program();
+    $php->setName('PHP');
+    $manager->persist($php);
+
+    $symfony = new Framework();
+    $symfony->setName('Symfony')
+      ->setDocUrl('https://symfony.com/doc/current/index.html')
+      ->setProgram($php);
+    $manager->persist($symfony);
+
+    $phpTopic = new TopicProgrammingLanguage();
+    $phpTopic->setProgrammingLanguage($php);
+    $manager->persist($phpTopic);
+
+    $symfonyTopic = new TopicFramework();
+    $symfonyTopic->setFramework($symfony);
+    $manager->persist($symfonyTopic);
+
+    $tutoPhp = new Ressource();
+    $tutoPhp->setAuthor($fabPot)
+      ->setLanguage('fr')
+      ->setLevel($intermediate)
+      ->setName('Découvrez les tableaux en PHP')
+      ->setUrl('https://symfony.com/doc/current/index.html')
+      ->setTopic($phpTopic);
+    $manager->persist($tutoPhp);
+
+    $tutoSymfony = new Ressource();
+    $tutoSymfony->setAuthor($fabPot)
+      ->setLanguage('fr')
+      ->setLevel($intermediate)
+      ->setName('Découvrez Symfony')
+      ->setUrl('https://symfony.com/doc/current/index.html')
+      ->setTopic($symfonyTopic);
+    $manager->persist($tutoSymfony);
+
+    $manager->flush();
+  }
 }

--- a/src/Entity/Framework.php
+++ b/src/Entity/Framework.php
@@ -3,8 +3,6 @@
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -36,14 +34,9 @@ class Framework
     private $docUrl;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Ressource", mappedBy="framework")
+     * @ORM\OneToOne(targetEntity="App\Entity\TopicFramework", mappedBy="framework", cascade={"persist", "remove"})
      */
-    private $ressources;
-
-    public function __construct()
-    {
-        $this->ressources = new ArrayCollection();
-    }
+    private $topic;
 
     public function getId(): ?int
     {
@@ -86,32 +79,18 @@ class Framework
         return $this;
     }
 
-    /**
-     * @return Collection|Ressource[]
-     */
-    public function getRessources(): Collection
+    public function getTopic(): ?TopicFramework
     {
-        return $this->ressources;
+        return $this->topic;
     }
 
-    public function addRessource(Ressource $ressource): self
+    public function setTopic(TopicFramework $topic): self
     {
-        if (!$this->ressources->contains($ressource)) {
-            $this->ressources[] = $ressource;
-            $ressource->setFramework($this);
-        }
+        $this->topic = $topic;
 
-        return $this;
-    }
-
-    public function removeRessource(Ressource $ressource): self
-    {
-        if ($this->ressources->contains($ressource)) {
-            $this->ressources->removeElement($ressource);
-            // set the owning side to null (unless already changed)
-            if ($ressource->getFramework() === $this) {
-                $ressource->setFramework(null);
-            }
+        // set the owning side of the relation if necessary
+        if ($topic->getFramework() !== $this) {
+            $topic->setFramework($this);
         }
 
         return $this;

--- a/src/Entity/Program.php
+++ b/src/Entity/Program.php
@@ -31,14 +31,13 @@ class Program
     private $frameworks;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Ressource", mappedBy="program", orphanRemoval=true)
+     * @ORM\OneToOne(targetEntity="App\Entity\TopicProgrammingLanguage", mappedBy="programmingLanguage", cascade={"persist", "remove"})
      */
-    private $ressources;
+    private $topic;
 
     public function __construct()
     {
         $this->frameworks = new ArrayCollection();
-        $this->ressources = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -89,32 +88,18 @@ class Program
         return $this;
     }
 
-    /**
-     * @return Collection|Ressource[]
-     */
-    public function getRessources(): Collection
+    public function getTopic(): ?TopicProgrammingLanguage
     {
-        return $this->ressources;
+        return $this->topic;
     }
 
-    public function addRessource(Ressource $ressource): self
+    public function setTopic(TopicProgrammingLanguage $topic): self
     {
-        if (!$this->ressources->contains($ressource)) {
-            $this->ressources[] = $ressource;
-            $ressource->setProgram($this);
-        }
+        $this->topic = $topic;
 
-        return $this;
-    }
-
-    public function removeRessource(Ressource $ressource): self
-    {
-        if ($this->ressources->contains($ressource)) {
-            $this->ressources->removeElement($ressource);
-            // set the owning side to null (unless already changed)
-            if ($ressource->getProgram() === $this) {
-                $ressource->setProgram(null);
-            }
+        // set the owning side of the relation if necessary
+        if ($topic->getProgrammingLanguage() !== $this) {
+            $topic->setProgrammingLanguage($this);
         }
 
         return $this;

--- a/src/Entity/Ressource.php
+++ b/src/Entity/Ressource.php
@@ -35,17 +35,6 @@ class Ressource
     private $author;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Program", inversedBy="ressources")
-     * @ORM\JoinColumn(nullable=false)
-     */
-    private $program;
-
-    /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Framework", inversedBy="ressources")
-     */
-    private $framework;
-
-    /**
      * @ORM\Column(type="string", length=255)
      */
     private $language;
@@ -55,6 +44,12 @@ class Ressource
      * @ORM\JoinColumn(nullable=false)
      */
     private $level;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="App\Entity\Topic", inversedBy="ressources")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $topic;
 
     public function getId(): ?int
     {
@@ -97,30 +92,6 @@ class Ressource
         return $this;
     }
 
-    public function getProgram(): ?Program
-    {
-        return $this->program;
-    }
-
-    public function setProgram(?Program $program): self
-    {
-        $this->program = $program;
-
-        return $this;
-    }
-
-    public function getFramework(): ?Framework
-    {
-        return $this->framework;
-    }
-
-    public function setFramework(?Framework $framework): self
-    {
-        $this->framework = $framework;
-
-        return $this;
-    }
-
     public function getLanguage(): ?string
     {
         return $this->language;
@@ -141,6 +112,18 @@ class Ressource
     public function setLevel(?Level $level): self
     {
         $this->level = $level;
+
+        return $this;
+    }
+
+    public function getTopic(): ?Topic
+    {
+        return $this->topic;
+    }
+
+    public function setTopic(?Topic $topic): self
+    {
+        $this->topic = $topic;
 
         return $this;
     }

--- a/src/Entity/Topic.php
+++ b/src/Entity/Topic.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource()
+ * @ORM\Entity(repositoryClass="App\Repository\TopicRepository")
+ * @ORM\InheritanceType("JOINED")
+ * @ORM\DiscriminatorColumn(name="discr", type="string")
+ * @ORM\DiscriminatorMap({
+ *   "framework" = "TopicFramework",
+ *   "programmingLanguage" = "TopicProgrammingLanguage"
+ * })
+ */
+abstract class Topic
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\Ressource", mappedBy="topic")
+     */
+    private $ressources;
+
+    public function __construct()
+    {
+        $this->ressources = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return Collection|Ressource[]
+     */
+    public function getRessources(): Collection
+    {
+        return $this->ressources;
+    }
+
+    public function addRessource(Ressource $ressource): self
+    {
+        if (!$this->ressources->contains($ressource)) {
+            $this->ressources[] = $ressource;
+            $ressource->setTopic($this);
+        }
+
+        return $this;
+    }
+
+    public function removeRessource(Ressource $ressource): self
+    {
+        if ($this->ressources->contains($ressource)) {
+            $this->ressources->removeElement($ressource);
+            // set the owning side to null (unless already changed)
+            if ($ressource->getTopic() === $this) {
+                $ressource->setTopic(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/Entity/TopicFramework.php
+++ b/src/Entity/TopicFramework.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource()
+ * @ORM\Entity(repositoryClass="App\Repository\TopicFrameworkRepository")
+ */
+class TopicFramework extends Topic
+{
+    /**
+     * @ORM\OneToOne(targetEntity="App\Entity\Framework", inversedBy="topic", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $framework;
+
+    public function getFramework(): ?Framework
+    {
+        return $this->framework;
+    }
+
+    public function setFramework(Framework $framework): self
+    {
+        $this->framework = $framework;
+
+        return $this;
+    }
+}

--- a/src/Entity/TopicProgrammingLanguage.php
+++ b/src/Entity/TopicProgrammingLanguage.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ApiResource()
+ * @ORM\Entity(repositoryClass="App\Repository\TopicProgrammingLanguageRepository")
+ */
+class TopicProgrammingLanguage extends Topic
+{
+  /**
+   * @ORM\OneToOne(targetEntity="App\Entity\Program", inversedBy="topic", cascade={"persist", "remove"})
+   * @ORM\JoinColumn(nullable=false)
+   */
+  private $programmingLanguage;
+
+  public function getProgrammingLanguage(): ?Program
+  {
+    return $this->programmingLanguage;
+  }
+
+  public function setProgrammingLanguage(Program $programmingLanguage): self
+  {
+    $this->programmingLanguage = $programmingLanguage;
+
+    return $this;
+  }
+}

--- a/src/Migrations/Version20200429122324.php
+++ b/src/Migrations/Version20200429122324.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200429122324 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE author (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, website VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE framework (id INT AUTO_INCREMENT NOT NULL, program_id INT DEFAULT NULL, name VARCHAR(255) NOT NULL, doc_url VARCHAR(255) NOT NULL, INDEX IDX_9D766E193EB8070A (program_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE level (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE program (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE ressource (id INT AUTO_INCREMENT NOT NULL, author_id INT NOT NULL, level_id INT NOT NULL, name VARCHAR(255) NOT NULL, url VARCHAR(255) NOT NULL, language VARCHAR(255) NOT NULL, INDEX IDX_939F4544F675F31B (author_id), INDEX IDX_939F45445FB14BA7 (level_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE framework ADD CONSTRAINT FK_9D766E193EB8070A FOREIGN KEY (program_id) REFERENCES program (id)');
+        $this->addSql('ALTER TABLE ressource ADD CONSTRAINT FK_939F4544F675F31B FOREIGN KEY (author_id) REFERENCES author (id)');
+        $this->addSql('ALTER TABLE ressource ADD CONSTRAINT FK_939F45445FB14BA7 FOREIGN KEY (level_id) REFERENCES level (id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ressource DROP FOREIGN KEY FK_939F4544F675F31B');
+        $this->addSql('ALTER TABLE ressource DROP FOREIGN KEY FK_939F45445FB14BA7');
+        $this->addSql('ALTER TABLE framework DROP FOREIGN KEY FK_9D766E193EB8070A');
+        $this->addSql('DROP TABLE author');
+        $this->addSql('DROP TABLE framework');
+        $this->addSql('DROP TABLE level');
+        $this->addSql('DROP TABLE program');
+        $this->addSql('DROP TABLE ressource');
+    }
+}

--- a/src/Migrations/Version20200429123339.php
+++ b/src/Migrations/Version20200429123339.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200429123339 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE topic (id INT AUTO_INCREMENT NOT NULL, discr VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE topic_framework (id INT NOT NULL, framework_id INT NOT NULL, UNIQUE INDEX UNIQ_74E3FAA137AECF72 (framework_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE topic_programming_language (id INT NOT NULL, programming_language_id INT NOT NULL, UNIQUE INDEX UNIQ_F6B03797A2574C1E (programming_language_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE topic_framework ADD CONSTRAINT FK_74E3FAA137AECF72 FOREIGN KEY (framework_id) REFERENCES framework (id)');
+        $this->addSql('ALTER TABLE topic_framework ADD CONSTRAINT FK_74E3FAA1BF396750 FOREIGN KEY (id) REFERENCES topic (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE topic_programming_language ADD CONSTRAINT FK_F6B03797A2574C1E FOREIGN KEY (programming_language_id) REFERENCES program (id)');
+        $this->addSql('ALTER TABLE topic_programming_language ADD CONSTRAINT FK_F6B03797BF396750 FOREIGN KEY (id) REFERENCES topic (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE ressource ADD topic_id INT NOT NULL');
+        $this->addSql('ALTER TABLE ressource ADD CONSTRAINT FK_939F45441F55203D FOREIGN KEY (topic_id) REFERENCES topic (id)');
+        $this->addSql('CREATE INDEX IDX_939F45441F55203D ON ressource (topic_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE ressource DROP FOREIGN KEY FK_939F45441F55203D');
+        $this->addSql('ALTER TABLE topic_framework DROP FOREIGN KEY FK_74E3FAA1BF396750');
+        $this->addSql('ALTER TABLE topic_programming_language DROP FOREIGN KEY FK_F6B03797BF396750');
+        $this->addSql('DROP TABLE topic');
+        $this->addSql('DROP TABLE topic_framework');
+        $this->addSql('DROP TABLE topic_programming_language');
+        $this->addSql('DROP INDEX IDX_939F45441F55203D ON ressource');
+        $this->addSql('ALTER TABLE ressource DROP topic_id');
+    }
+}

--- a/src/Repository/TopicFrameworkRepository.php
+++ b/src/Repository/TopicFrameworkRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\TopicFramework;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method TopicFramework|null find($id, $lockMode = null, $lockVersion = null)
+ * @method TopicFramework|null findOneBy(array $criteria, array $orderBy = null)
+ * @method TopicFramework[]    findAll()
+ * @method TopicFramework[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class TopicFrameworkRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TopicFramework::class);
+    }
+
+    // /**
+    //  * @return TopicFramework[] Returns an array of TopicFramework objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('t.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?TopicFramework
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/src/Repository/TopicProgrammingLanguageRepository.php
+++ b/src/Repository/TopicProgrammingLanguageRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\TopicProgrammingLanguage;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method TopicProgrammingLanguage|null find($id, $lockMode = null, $lockVersion = null)
+ * @method TopicProgrammingLanguage|null findOneBy(array $criteria, array $orderBy = null)
+ * @method TopicProgrammingLanguage[]    findAll()
+ * @method TopicProgrammingLanguage[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class TopicProgrammingLanguageRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TopicProgrammingLanguage::class);
+    }
+
+    // /**
+    //  * @return TopicProgrammingLanguage[] Returns an array of TopicProgrammingLanguage objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('t.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?TopicProgrammingLanguage
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}

--- a/src/Repository/TopicRepository.php
+++ b/src/Repository/TopicRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Topic;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Topic|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Topic|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Topic[]    findAll()
+ * @method Topic[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class TopicRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Topic::class);
+    }
+
+    // /**
+    //  * @return Topic[] Returns an array of Topic objects
+    //  */
+    /*
+    public function findByExampleField($value)
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.exampleField = :val')
+            ->setParameter('val', $value)
+            ->orderBy('t.id', 'ASC')
+            ->setMaxResults(10)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+    */
+
+    /*
+    public function findOneBySomeField($value): ?Topic
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.exampleField = :val')
+            ->setParameter('val', $value)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+    */
+}


### PR DESCRIPTION
Comme je vous en parlais tout à l'heure :

L'idée est de créer une entité `Topic`, liée à l'entité `Ressource`.
Ensuite, 2 entités supplémentaires sont créées, qui héritent de `Topic` : `TopicFramework` et `TopicProgrammingLanguage` (j'ai laissé "Topic" en premier mot pour qu'elles soient regroupées les unes en-dessous des autres, plus facile à explorer je trouve. Mais vous pouvez les nommer `FrameworkTopic` et `ProgrammingLanguageTopic` si vous le souhaitez bien sûr).

J'ai choisi la stratégie [Class Table Inheritance](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/inheritance-mapping.html#class-table-inheritance) afin que les topics enfants soient liées à un `Topic` par une clé étrangère.

Ainsi, votre modèle pourra évoluer plus tard avec de nouveaux topics concrets, sans avoir à retoucher quoi que ce soit.

Autre point : vous remarquerez que la classe `Topic` est abstraite, car on souhaite travailler uniquement avec des `TopicFramework` ou bien des `ProgrammingLanguageTopic`, pas un `Topic` général, relié à rien, dont on ne saurait pas quoi faire...

J'ai séparé les migrations en 2 : d'abord une sans les topics, puis une migration qui vient les rajouter.

Vous pouvez donc tenter d'exécuter ces migrations, puis importer les fixtures.

Ensuite, mettez votre serveur en route et explorez l'API à l'URL `/api`. Avec la doc OpenAPI, vous pourrez tester les endpoints. Vous verrez donc que le lien abstrait vers un `Topic`, dans une ressource, renvoie bien un `TopicFramework` ou bien un `TopicProgrammingLanguage` selon le cas.

**C'est une première version, pour vous donner un exemple. Je n'ai pas inclus le moindre groupe de sérialisation donc ce sera à vous de voir ça selon vos besoins. Par ailleurs, vous restez libres de faire comme ça ou pas, cela dépend de ce dont vous avez besoin ! Je n'ai pas automatisé la création d'un Topic suite à la création d'un Framework ou d'un langage, également, il faut y réfléchir...**